### PR TITLE
feat: must_not_pair ポスト処理バリデーターを追加

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,10 +35,12 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "@vitest/coverage-v8": "^4.1.7",
         "eslint": "^9",
         "eslint-config-next": "16.2.3",
         "tailwindcss": "^4",
-        "typescript": "^5"
+        "typescript": "^5",
+        "vitest": "^4.1.7"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -317,9 +319,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -521,6 +523,16 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
+      "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@date-fns/tz": {
@@ -781,28 +793,6 @@
       },
       "peerDependencies": {
         "@noble/ciphers": "^1.0.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.2.tgz",
-      "integrity": "sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -2005,6 +1995,16 @@
       "integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
       "license": "MIT"
     },
+    "node_modules/@oxc-project/types": {
+      "version": "0.132.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.132.0.tgz",
+      "integrity": "sha512-FESMOxil5Se014ui/Eq8fT5uHJo6nIRwH0PfJrZJXs6Gek3ZVFOrpUv3YIZT20m+extU98Hg1Ym72U58rlsxUQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
     "node_modules/@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
@@ -2026,6 +2026,289 @@
       "peerDependencies": {
         "react": ">=16.8.0"
       }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.2.tgz",
+      "integrity": "sha512-ZS4D1JPGn/MYQN/SYDWftIE/nVsM8j/AFOYEzAoOE2O3NktQOZru+/vYXGbR/qtdLdIfGCP0lcoJiYVzsEz+iQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.2.tgz",
+      "integrity": "sha512-vdFA9+C/rekyGce7WqHs/xoT0ioZEWaOFyZLIV1mEeNFaFDUQrPIo8Vs2GvJ6eetb3rzDUtUBgzto3ExpXJB3w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.2.tgz",
+      "integrity": "sha512-BewSOwTHazv77DTYiAZXSqqKZ4KP/KonFisDMVU7PImxoWfB2aepnPhd2E4SWz3zDzYgDNbs6jBmTdgNnF02GA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.2.tgz",
+      "integrity": "sha512-m41o7M0YWtUdqk61Tb+jnKb2rN++iRdIASlExkUoKfIAH30DOHCB8fVLzSUpbWHHU8esmEioY62PxzexE8MBuA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.2.tgz",
+      "integrity": "sha512-jcojB9H7W/jS29pMKWAK1N+fU99vXodHDTatS3b3y/XSOCiHo0kkA74pL3jJmkoQtYpOCxDvaKs1fo2Ij/1X5w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.2.tgz",
+      "integrity": "sha512-1jn6qDU5iiOgFgygDzKUuKP0maTi0/f1+sBLgvij/76C77Nm3ts6ufz9Bjg5q5dduxiUIxtq86JIoBvo1xQ4Ig==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.2.tgz",
+      "integrity": "sha512-QVLO/czFMdoMFSqlX3bcswcJNm/23r+qoa/jgtmFc/qEp6/jXmIkDjF/XIo8dPfGaiwy1xfQn8o77L79GeXFgw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.2.tgz",
+      "integrity": "sha512-hgO5Abm0w5UL6FEa2iFnZqo2KlK7TQ5QhV5x09hujBf7t5KzHQ1VmfPuTpqRy/rNlSxua3eWH374xxiVrP+lcA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.2.tgz",
+      "integrity": "sha512-fy8rXxuYEu602abC8MUNaPjYLIFzReOaEIEMKMUa0rFEUxNpVXhs15KSSQ4qlqSaM7B6rcj9rDZgADh/IGDzLQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.2.tgz",
+      "integrity": "sha512-0+bOkiQ779+r1WpoHOWHqncvyySci0vKph+myNDYb+im6meJAzHQXay6oEgnkHuUGouM1LKTZwqKpBow6Kj7CQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.2.tgz",
+      "integrity": "sha512-mjSkrzZK5Qsl0a9d1JgILOiuZOSDTVdKENcSXBoqbzSrspLR/4/IRVDo5wd2GgZjNss/viBFJdeq+j7qH2nypw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.2.tgz",
+      "integrity": "sha512-1v5vHasdfQAZoEHakBV72LIFAC9JjnymsiKxp+GEr/ma3+NJCPSaYK+qavInOovJkgwFrs7GccX2d6IgDA3Z5w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.2.tgz",
+      "integrity": "sha512-mb1VobWn6NheziTk5/WEaR6AKVbrwT5sOi6C7zk3gy/pD1qtJfU1j4PgTo2NJnOtbL9Dl3Aeei8w9jJ7qC2jZQ==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.2.tgz",
+      "integrity": "sha512-SqKonF56vA/L2yHwHYcEp2P34URpOZ7d1fS635cTkpDnUtEGdUbhI6NzsPdqeSWvAAeGDrxjWjNmibDIdFf9/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.2.tgz",
+      "integrity": "sha512-v7qRI7gXLRINcOGXt+7YmAZ6iFuyZVMIoXAxhd8oP+DR9dLfL9GfNIx7PLMxmhZdvq8waUJBQiWN9EKNy+TRBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
@@ -2051,6 +2334,13 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@supabase/auth-js": {
       "version": "2.103.0",
@@ -2452,9 +2742,9 @@
       }
     },
     "node_modules/@ts-morph/common/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
@@ -2517,10 +2807,28 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/date-arithmetic": {
       "version": "4.1.4",
       "resolved": "https://registry.npmjs.org/@types/date-arithmetic/-/date-arithmetic-4.1.4.tgz",
       "integrity": "sha512-p9eZ2X9B80iKiTW4ukVj8B4K6q9/+xFtQ5MGYA5HWToY9nL4EkhV9+6ftT2VHpVMEZb5Tv00Iel516bVdO+yRw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -2817,9 +3125,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3182,6 +3490,151 @@
         "win32"
       ]
     },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-4.1.7.tgz",
+      "integrity": "sha512-qsYPeXc5Q9dFLd1i8Ap+Bx8sQgcp+rFVQo4R0dDsWNBzl26ldVF1qOO+RL24K7FDrR6pA+50XedRLSoSG24bVQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@bcoe/v8-coverage": "^1.0.2",
+        "@vitest/utils": "4.1.7",
+        "ast-v8-to-istanbul": "^1.0.0",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-reports": "^3.2.0",
+        "magicast": "^0.5.2",
+        "obug": "^2.1.1",
+        "std-env": "^4.0.0-rc.1",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "4.1.7",
+        "vitest": "4.1.7"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.7.tgz",
+      "integrity": "sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.7.tgz",
+      "integrity": "sha512-vY7nuamKgfvpA1Koa3oYIw/k7D6kZnpGyNMZW8loow2bsBYla1TFdqTaXncWdRn4pgwNs+90RhnXhJScDwQeJA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.7",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.7.tgz",
+      "integrity": "sha512-umgCarTOYQWIaDMvGDRZij+6b9oVeLIyJzfN+AS88e0ZOU3QTgNNSTtjQOpcvWr3np1N0j4WgZj+sb3oYBDscw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.7.tgz",
+      "integrity": "sha512-BapjmAQ2aI78WdMEfeUWivnfVzB+VPGwWRQcJE0OUq7qEeEcBsCSf+0T5iREBNE5nBb4wA5Ya0W6IA+sghdEFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.7",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.7.tgz",
+      "integrity": "sha512-ZacLzja+TmJeZ1h14xW2FB/WpeimUD3haBXQPyJqxvo8jQTmfeA8zv58mtjN2C7EHXZDYVcVYdYmAxjkWVvKCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.7.tgz",
+      "integrity": "sha512-kbkI5LMWakyuTIvs6fUJ5qdIVb1XVKsYJAT4OJ938cHMROYMSfmoQdZy0aaAnjbbc8F61vkoTqz/Az+/HiIu5Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.7.tgz",
+      "integrity": "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.7",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/accepts": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
@@ -3487,6 +3940,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/ast-types": {
       "version": "0.16.1",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.16.1.tgz",
@@ -3503,6 +3966,25 @@
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.8.tgz",
       "integrity": "sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ast-v8-to-istanbul": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/ast-v8-to-istanbul/-/ast-v8-to-istanbul-1.0.0.tgz",
+      "integrity": "sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.31",
+        "estree-walker": "^3.0.3",
+        "js-tokens": "^10.0.0"
+      }
+    },
+    "node_modules/ast-v8-to-istanbul/node_modules/js-tokens": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-10.0.0.tgz",
+      "integrity": "sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -3752,6 +4234,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4564,6 +5056,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -5062,6 +5561,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -5128,6 +5637,16 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/express": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
@@ -5172,12 +5691,12 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.2.tgz",
-      "integrity": "sha512-77VmFeJkO0/rvimEDuUC5H30oqUC4EyOhyGccfqoLebB0oiEYfM7nwPrsDsBL1gsTpwfzX8SFy2MT3TDyRq+bg==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5249,9 +5768,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -5453,6 +5972,21 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/function-bind": {
@@ -5840,14 +6374,21 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.21",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.21.tgz",
+      "integrity": "sha512-uV63apnb0kyPtAUwoWgaGh9HyIFcv8lgmzPZSiTBQAFOFGIzka5EZ1dZocmGnn0XdX0+XTqJ6Tqv7selMuGLRQ==",
       "license": "MIT",
       "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/http-errors": {
       "version": "2.0.1",
@@ -5982,9 +6523,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "license": "MIT",
       "engines": {
         "node": ">= 12"
@@ -6583,6 +7124,45 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "license": "ISC"
     },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/iterator.prototype": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/iterator.prototype/-/iterator.prototype-1.1.5.tgz",
@@ -7167,6 +7747,47 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/magicast": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.5.3.tgz",
+      "integrity": "sha512-pVKE4UdSQ7DvHzivsCIFx2BJn1mHG6KsyrFcaxFx6tONdneEuThrDx0Cj3AMg58KyN4pzYT+LHOotxDQDjNvkw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.3",
+        "@babel/types": "^7.29.0",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -7380,9 +8001,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -7731,6 +8352,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/on-finished": {
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
@@ -7991,6 +8623,13 @@
       "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
       "license": "MIT"
     },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -8029,9 +8668,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.9",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.9.tgz",
-      "integrity": "sha512-7a70Nsot+EMX9fFU3064K/kdHWZqGVY+BADLyXc8Dfv+mTLLVl6JzJpPaCZ2kQL9gIJvKXSLMHhqdRRjwQeFtw==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -8048,7 +8687,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8479,6 +9118,40 @@
       "engines": {
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rolldown": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.2.tgz",
+      "integrity": "sha512-oZx5zVDtVB44AW3eaifgDml1gWRDZGvjcfdxonE4swNPG98PrrXjaO/KrnUjzlMnztCCRVlUueA1kCXhARGk6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@oxc-project/types": "=0.132.0",
+        "@rolldown/pluginutils": "^1.0.0"
+      },
+      "bin": {
+        "rolldown": "bin/cli.mjs"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "optionalDependencies": {
+        "@rolldown/binding-android-arm64": "1.0.2",
+        "@rolldown/binding-darwin-arm64": "1.0.2",
+        "@rolldown/binding-darwin-x64": "1.0.2",
+        "@rolldown/binding-freebsd-x64": "1.0.2",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.2",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.2",
+        "@rolldown/binding-linux-arm64-musl": "1.0.2",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.2",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-gnu": "1.0.2",
+        "@rolldown/binding-linux-x64-musl": "1.0.2",
+        "@rolldown/binding-openharmony-arm64": "1.0.2",
+        "@rolldown/binding-wasm32-wasi": "1.0.2",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.2",
+        "@rolldown/binding-win32-x64-msvc": "1.0.2"
       }
     },
     "node_modules/router": {
@@ -8965,6 +9638,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -9008,6 +9688,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -9016,6 +9703,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/std-env": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",
@@ -9349,6 +10043,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.16",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
@@ -9396,6 +10107,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tldts": {
@@ -9859,6 +10580,202 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/vite": {
+      "version": "8.0.14",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.14.tgz",
+      "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.2",
+        "tinyglobby": "^0.2.16"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "4.1.7",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.7.tgz",
+      "integrity": "sha512-flYyaFd2CgoCoU+0UKt3pxksgC+S02iTDN0n3LtqaMeXsI9SBcdNujc2k0DeFLzUn/0k538yNjOSdwgCqcrwJA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vitest/expect": "4.1.7",
+        "@vitest/mocker": "4.1.7",
+        "@vitest/pretty-format": "4.1.7",
+        "@vitest/runner": "4.1.7",
+        "@vitest/snapshot": "4.1.7",
+        "@vitest/spy": "4.1.7",
+        "@vitest/utils": "4.1.7",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.7",
+        "@vitest/browser-preview": "4.1.7",
+        "@vitest/browser-webdriverio": "4.1.7",
+        "@vitest/coverage-istanbul": "4.1.7",
+        "@vitest/coverage-v8": "4.1.7",
+        "@vitest/ui": "4.1.7",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/warning": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
@@ -9981,6 +10898,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -10053,9 +10987,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -6,7 +6,10 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   },
   "dependencies": {
     "@base-ui/react": "^1.4.0",
@@ -36,9 +39,11 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@vitest/coverage-v8": "^4.1.7",
     "eslint": "^9",
     "eslint-config-next": "16.2.3",
     "tailwindcss": "^4",
-    "typescript": "^5"
+    "typescript": "^5",
+    "vitest": "^4.1.7"
   }
 }

--- a/src/app/api/shift/generate/route.ts
+++ b/src/app/api/shift/generate/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server'
 import { getDaysInMonth, getDay } from 'date-fns'
 import { generateShifts } from '@/lib/shift-solver'
 import { generateShiftsFallback } from '@/lib/shift-solver-fallback'
+import { validateAndFixPairConstraints } from '@/lib/shift-validator'
 
 export async function POST(request: Request) {
   const body = await request.json().catch(() => null)
@@ -133,6 +134,15 @@ export async function POST(request: Request) {
     resultStatus = fallback.solverStatus
     fallbackUsed = true
   }
+
+  // ポスト処理: CSP/フォールバック後に must_not_pair 違反を検出・修正
+  validateAndFixPairConstraints(
+    grid,
+    solverInput.pairConstraints,
+    solverInput.staff,
+    warnings,
+    solverInput.constraints?.max_consecutive_work_days ?? 5,
+  )
 
   return NextResponse.json({
     grid,

--- a/src/lib/__tests__/pair-target.test.ts
+++ b/src/lib/__tests__/pair-target.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest'
+import { pairTargetsNight, pairTargetsDay } from '../shift-solver-csp'
+import type { StaffPairConstraint } from '@/types'
+
+function makePair(overrides: Partial<StaffPairConstraint> = {}): StaffPairConstraint {
+  return {
+    id: 'pair-1',
+    staff_id_a: 'staff-a',
+    staff_id_b: 'staff-b',
+    constraint_type: 'must_not_pair',
+    shift_type_id: null,
+    note: null,
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+describe('pairTargetsNight', () => {
+  it('shift_type_id が null のとき true（全シフト対象）', () => {
+    expect(pairTargetsNight(makePair({ shift_type_id: null }))).toBe(true)
+  })
+
+  it('is_overnight = true のとき true（夜勤専用制約）', () => {
+    expect(
+      pairTargetsNight(
+        makePair({
+          shift_type_id: 'night-type-id',
+          shift_type: { id: 'night-type-id', name: '夜勤', is_overnight: true, is_off: false },
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('is_overnight = false のとき false（日勤専用制約は夜勤に影響しない）', () => {
+    expect(
+      pairTargetsNight(
+        makePair({
+          shift_type_id: 'day-type-id',
+          shift_type: { id: 'day-type-id', name: '日勤', is_overnight: false, is_off: false },
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('shift_type_id が非 null で shift_type が未定義のとき false（型情報なし）', () => {
+    expect(pairTargetsNight(makePair({ shift_type_id: 'some-id', shift_type: undefined }))).toBe(false)
+  })
+})
+
+describe('pairTargetsDay', () => {
+  it('shift_type_id が null のとき true（全シフト対象）', () => {
+    expect(pairTargetsDay(makePair({ shift_type_id: null }))).toBe(true)
+  })
+
+  it('is_overnight = false のとき true（日勤専用制約）', () => {
+    expect(
+      pairTargetsDay(
+        makePair({
+          shift_type_id: 'day-type-id',
+          shift_type: { id: 'day-type-id', name: '日勤', is_overnight: false, is_off: false },
+        }),
+      ),
+    ).toBe(true)
+  })
+
+  it('is_overnight = true のとき false（夜勤専用制約は日勤に影響しない）', () => {
+    expect(
+      pairTargetsDay(
+        makePair({
+          shift_type_id: 'night-type-id',
+          shift_type: { id: 'night-type-id', name: '夜勤', is_overnight: true, is_off: false },
+        }),
+      ),
+    ).toBe(false)
+  })
+
+  it('shift_type_id が非 null で shift_type が未定義のとき false（型情報なし）', () => {
+    expect(pairTargetsDay(makePair({ shift_type_id: 'some-id', shift_type: undefined }))).toBe(false)
+  })
+})

--- a/src/lib/__tests__/shift-solver-fallback-pair.test.ts
+++ b/src/lib/__tests__/shift-solver-fallback-pair.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from 'vitest'
+import { generateShiftsFallback } from '../shift-solver-fallback'
+import type { SolverInput, ShiftGrid } from '../shift-solver'
+import type { ShiftConstraints, ShiftType, StaffPairConstraint, StaffProfile } from '@/types'
+
+// ──────────────────────────────────────────────
+// フィクスチャ
+// ──────────────────────────────────────────────
+
+const NIGHT_TYPE: ShiftType = {
+  id: 'night-type',
+  name: '夜勤',
+  start_time: '16:30',
+  end_time: '09:00',
+  is_overnight: true,
+  is_off: false,
+  color: '#333',
+  display_order: 1,
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+const DAY_TYPE: ShiftType = {
+  id: 'day-type',
+  name: '日勤',
+  start_time: '08:30',
+  end_time: '17:30',
+  is_overnight: false,
+  is_off: false,
+  color: '#fff',
+  display_order: 0,
+  created_at: '2026-01-01T00:00:00Z',
+}
+
+function makeStaff(id: string, overrides: Partial<StaffProfile> = {}): StaffProfile {
+  return {
+    id,
+    name: `スタッフ_${id}`,
+    qualification: '正看護師',
+    role: '一般',
+    work_start_time: '08:30',
+    work_end_time: '17:30',
+    max_night_shifts: 6,
+    experience_years: 3,
+    off_days_of_week: [],
+    off_on_holidays: false,
+    off_days_constraint: 'soft',
+    allow_extra_off_days: true,
+    is_active: true,
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const BASE_CONSTRAINTS: ShiftConstraints = {
+  id: 'c1',
+  year_month: '2026-06',
+  min_staff_per_shift: { '夜勤': 2, '日勤': 2 },
+  max_staff_per_shift: { '夜勤': 3, '日勤': 5 },
+  min_staff_weekend: 2,
+  max_staff_weekend: 4,
+  min_staff_bath_day: 3,
+  max_consecutive_work_days: 5,
+  min_rest_hours_after_night: 16,
+  auto_insert_off_after_night: true,
+  target_off_days: 8,
+  bath_days_of_week: [],
+  updated_at: '2026-01-01T00:00:00Z',
+}
+
+// staff-a と staff-b がテスト対象ペア、残り3名はペア制約なし
+const ALL_STAFF: StaffProfile[] = [
+  makeStaff('staff-a'),
+  makeStaff('staff-b'),
+  makeStaff('staff-c'),
+  makeStaff('staff-d'),
+  makeStaff('staff-e'),
+]
+
+function makeBaseInput(pairConstraints: StaffPairConstraint[]): SolverInput {
+  return {
+    yearMonth: '2026-06',
+    staff: ALL_STAFF,
+    constraints: BASE_CONSTRAINTS,
+    leaveRequests: [],
+    pairConstraints,
+    shiftTypes: [NIGHT_TYPE, DAY_TYPE],
+    bathDayIndices: [],
+  }
+}
+
+function makePairConstraint(overrides: Partial<StaffPairConstraint> = {}): StaffPairConstraint {
+  return {
+    id: 'pair-1',
+    staff_id_a: 'staff-a',
+    staff_id_b: 'staff-b',
+    constraint_type: 'must_not_pair',
+    shift_type_id: null,
+    note: null,
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+// ──────────────────────────────────────────────
+// ヘルパー
+// ──────────────────────────────────────────────
+
+function hasPairViolation(
+  grid: ShiftGrid,
+  idA: string,
+  idB: string,
+  code: '夜' | '日',
+  daysInMonth: number,
+): boolean {
+  for (let d = 0; d < daysInMonth; d++) {
+    if (grid[idA][d] === code && grid[idB][d] === code) return true
+  }
+  return false
+}
+
+// ──────────────────────────────────────────────
+// テスト
+// ──────────────────────────────────────────────
+
+describe('generateShiftsFallback — must_not_pair 制約', () => {
+  const DAYS = 30 // 2026-06 は30日
+
+  it('ペア制約なしのとき正常に生成できる（ベースライン）', async () => {
+    const result = await generateShiftsFallback(makeBaseInput([]))
+    expect(result.solverStatus).toBe('success')
+    expect(result.grid['staff-a']).toHaveLength(DAYS)
+  })
+
+  it('全シフト対象のペア禁止: staff-a と staff-b が同日夜勤にならない', async () => {
+    const constraint = makePairConstraint({ shift_type_id: null })
+    const result = await generateShiftsFallback(makeBaseInput([constraint]))
+
+    expect(result.solverStatus).toBe('success')
+    expect(hasPairViolation(result.grid, 'staff-a', 'staff-b', '夜', DAYS)).toBe(false)
+  })
+
+  it('全シフト対象のペア禁止: staff-a と staff-b が同日日勤にならない', async () => {
+    const constraint = makePairConstraint({ shift_type_id: null })
+    const result = await generateShiftsFallback(makeBaseInput([constraint]))
+
+    expect(result.solverStatus).toBe('success')
+    expect(hasPairViolation(result.grid, 'staff-a', 'staff-b', '日', DAYS)).toBe(false)
+  })
+
+  it('夜勤専用ペア禁止: 夜勤で違反しない', async () => {
+    const constraint = makePairConstraint({
+      shift_type_id: NIGHT_TYPE.id,
+      shift_type: { id: NIGHT_TYPE.id, name: NIGHT_TYPE.name, is_overnight: true, is_off: false },
+    })
+    const result = await generateShiftsFallback(makeBaseInput([constraint]))
+
+    expect(result.solverStatus).toBe('success')
+    expect(hasPairViolation(result.grid, 'staff-a', 'staff-b', '夜', DAYS)).toBe(false)
+  })
+
+  it('日勤専用ペア禁止: 日勤で違反しない', async () => {
+    const constraint = makePairConstraint({
+      shift_type_id: DAY_TYPE.id,
+      shift_type: { id: DAY_TYPE.id, name: DAY_TYPE.name, is_overnight: false, is_off: false },
+    })
+    const result = await generateShiftsFallback(makeBaseInput([constraint]))
+
+    expect(result.solverStatus).toBe('success')
+    expect(hasPairViolation(result.grid, 'staff-a', 'staff-b', '日', DAYS)).toBe(false)
+  })
+
+  it('日勤専用ペア禁止: 日勤違反が発生しない（夜勤はスコープ外）', async () => {
+    const constraint = makePairConstraint({
+      shift_type_id: DAY_TYPE.id,
+      shift_type: { id: DAY_TYPE.id, name: DAY_TYPE.name, is_overnight: false, is_off: false },
+    })
+    const result = await generateShiftsFallback(makeBaseInput([constraint]))
+
+    expect(result.solverStatus).toBe('success')
+    // 日勤専用制約なので日勤ペアは許容されない
+    expect(hasPairViolation(result.grid, 'staff-a', 'staff-b', '日', DAYS)).toBe(false)
+    // 夜勤はこの制約のスコープ外（夜勤ペアが発生しても制約違反ではない）
+  })
+})

--- a/src/lib/__tests__/shift-validator.test.ts
+++ b/src/lib/__tests__/shift-validator.test.ts
@@ -1,0 +1,404 @@
+import { describe, it, expect } from 'vitest'
+import { validateAndFixPairConstraints } from '../shift-validator'
+import type { ShiftGrid } from '../shift-solver'
+import type { StaffPairConstraint, StaffProfile } from '@/types'
+
+// ──────────────────────────────────────────────
+// フィクスチャ
+// ──────────────────────────────────────────────
+
+function makeStaff(id: string): StaffProfile {
+  return {
+    id,
+    name: `スタッフ_${id}`,
+    qualification: '正看護師',
+    role: '一般',
+    work_start_time: '08:30',
+    work_end_time: '17:30',
+    max_night_shifts: 6,
+    experience_years: 3,
+    off_days_of_week: [],
+    off_on_holidays: false,
+    off_days_constraint: 'soft',
+    allow_extra_off_days: true,
+    is_active: true,
+    sort_order: 0,
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+  }
+}
+
+function makePair(overrides: Partial<StaffPairConstraint> = {}): StaffPairConstraint {
+  return {
+    id: 'pair-1',
+    staff_id_a: 'staff-a',
+    staff_id_b: 'staff-b',
+    constraint_type: 'must_not_pair',
+    shift_type_id: null,
+    note: null,
+    created_at: '2026-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+const DAYS = 7
+const ALL_STAFF = [makeStaff('staff-a'), makeStaff('staff-b'), makeStaff('staff-c'), makeStaff('staff-d')]
+
+function emptyGrid(days = DAYS): ShiftGrid {
+  return Object.fromEntries(ALL_STAFF.map((s) => [s.id, Array(days).fill('') as string[]]))
+}
+
+// ──────────────────────────────────────────────
+// 基本動作
+// ──────────────────────────────────────────────
+
+describe('validateAndFixPairConstraints — 基本動作', () => {
+  it('違反がない場合はグリッドを変更しない', () => {
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-c'][0] = '夜'
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings)
+
+    expect(grid['staff-a'][0]).toBe('夜')
+    expect(grid['staff-c'][0]).toBe('夜')
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('スタッフが空の場合は何もしない', () => {
+    const warnings: string[] = []
+    validateAndFixPairConstraints({}, [makePair()], [], warnings)
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('must_pair 制約はスキップする', () => {
+    const mustPair = makePair({ constraint_type: 'must_pair' })
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-b'][1] = '夜'
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [mustPair], ALL_STAFF, warnings)
+
+    expect(warnings).toHaveLength(0)
+  })
+
+  it('staff_id_a がグリッドに存在しない場合はクラッシュしない', () => {
+    const grid = emptyGrid()
+    const unknownPair = makePair({ staff_id_a: 'unknown-id' })
+    const warnings: string[] = []
+    expect(() => validateAndFixPairConstraints(grid, [unknownPair], ALL_STAFF, warnings)).not.toThrow()
+  })
+})
+
+// ──────────────────────────────────────────────
+// 夜勤ペア違反
+// ──────────────────────────────────────────────
+
+describe('validateAndFixPairConstraints — 夜勤ペア違反', () => {
+  it('staff-b を解放し代替スタッフを充填する', () => {
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-b'][0] = '夜'
+    grid['staff-a'][1] = '明'
+    grid['staff-b'][1] = '明'
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings)
+
+    expect(grid['staff-a'][0]).toBe('夜')
+    expect(grid['staff-b'][0]).toBe('')
+    expect(grid['staff-b'][1]).toBe('')
+    const refilled = ['staff-c', 'staff-d'].some((id) => grid[id][0] === '夜')
+    expect(refilled).toBe(true)
+    expect(warnings.some((w) => w.includes('再充填'))).toBe(true)
+  })
+
+  it('夜勤解放時に翌々日の公休も解放する', () => {
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-b'][0] = '夜'
+    grid['staff-a'][1] = '明'
+    grid['staff-b'][1] = '明'
+    grid['staff-b'][2] = '公' // 夜勤後の自動挿入
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings)
+
+    expect(grid['staff-b'][0]).toBe('')
+    expect(grid['staff-b'][1]).toBe('')
+    expect(grid['staff-b'][2]).toBe('') // 公も解放される
+  })
+
+  it('代替スタッフが全員不可の場合は空きのまま警告する', () => {
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-b'][0] = '夜'
+    grid['staff-a'][1] = '明'
+    grid['staff-b'][1] = '明'
+    // staff-c, staff-d を dayIdx=0 に埋める（canTakeNight で弾かれる）
+    grid['staff-c'][0] = '日'
+    grid['staff-d'][0] = '日'
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings)
+
+    expect(grid['staff-b'][0]).toBe('')
+    expect(warnings.some((w) => w.includes('代替スタッフが見つかりませんでした'))).toBe(true)
+  })
+
+  it('月末（最終日）の夜勤違反で翌日チェックが境界外にはみ出さない', () => {
+    const days = 3
+    const grid: ShiftGrid = Object.fromEntries(
+      ALL_STAFF.map((s) => [s.id, Array(days).fill('') as string[]]),
+    )
+    // 最終日（dayIdx=2）に夜勤ペア違反
+    grid['staff-a'][2] = '夜'
+    grid['staff-b'][2] = '夜'
+
+    const warnings: string[] = []
+    expect(() => validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings)).not.toThrow()
+    expect(grid['staff-b'][2]).toBe('')
+  })
+
+  it('連続勤務上限に達したスタッフは再充填候補にならない', () => {
+    // maxConsecutive = 2
+    const grid = emptyGrid()
+    grid['staff-a'][2] = '夜'
+    grid['staff-b'][2] = '夜'
+    grid['staff-a'][3] = '明'
+    grid['staff-b'][3] = '明'
+    // staff-c は dayIdx=1,2 に日勤（連続2日 → dayIdx=2+1=3なので streak=2、maxConsecutive=2）
+    // dayIdx=2 の夜勤: streak=1 (dayIdx-1=1 が '日' → isWork → 2) → 2 > 2 → 不可
+    grid['staff-c'][0] = '日'
+    grid['staff-c'][1] = '日' // streak 2日分
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings, 2)
+
+    // staff-c は連続勤務超過で候補にならない（staff-d が充填されるか、代替なし）
+    // staff-d は空きなので充填される
+    expect(grid['staff-c'][2]).not.toBe('夜')
+  })
+})
+
+// ──────────────────────────────────────────────
+// 日勤ペア違反
+// ──────────────────────────────────────────────
+
+describe('validateAndFixPairConstraints — 日勤ペア違反', () => {
+  it('staff-b を解放し代替スタッフを充填する', () => {
+    const grid = emptyGrid()
+    grid['staff-a'][2] = '日'
+    grid['staff-b'][2] = '日'
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings)
+
+    expect(grid['staff-a'][2]).toBe('日')
+    expect(grid['staff-b'][2]).toBe('')
+    const refilled = ['staff-c', 'staff-d'].some((id) => grid[id][2] === '日')
+    expect(refilled).toBe(true)
+  })
+
+  it('翌日が夜勤の候補は日勤に充填しない', () => {
+    const grid = emptyGrid()
+    grid['staff-a'][2] = '日'
+    grid['staff-b'][2] = '日'
+    // staff-c の dayIdx=3 が '夜' → canTakeDay で dayIdx+1===夜 で弾かれる
+    grid['staff-c'][3] = '夜'
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings)
+
+    // staff-c は候補にならない
+    expect(grid['staff-c'][2]).not.toBe('日')
+    // staff-d が充填される
+    expect(grid['staff-d'][2]).toBe('日')
+  })
+})
+
+// ──────────────────────────────────────────────
+// シフト種別限定ペア
+// ──────────────────────────────────────────────
+
+describe('validateAndFixPairConstraints — シフト種別限定', () => {
+  it('夜勤専用ペア禁止: 夜勤違反を修正し日勤は対象外', () => {
+    const nightOnlyPair = makePair({
+      shift_type_id: 'night-type',
+      shift_type: { id: 'night-type', name: '夜勤', is_overnight: true, is_off: false },
+    })
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-b'][0] = '夜' // 夜勤違反 → 修正
+    grid['staff-a'][1] = '日'
+    grid['staff-b'][1] = '日' // 日勤はスコープ外 → そのまま
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [nightOnlyPair], ALL_STAFF, warnings)
+
+    expect(grid['staff-b'][0]).toBe('')
+    expect(grid['staff-a'][1]).toBe('日')
+    expect(grid['staff-b'][1]).toBe('日')
+  })
+
+  it('日勤専用ペア禁止: 日勤違反を修正し夜勤は対象外', () => {
+    const dayOnlyPair = makePair({
+      shift_type_id: 'day-type',
+      shift_type: { id: 'day-type', name: '日勤', is_overnight: false, is_off: false },
+    })
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-b'][0] = '夜' // 夜勤はスコープ外 → そのまま
+    grid['staff-a'][2] = '日'
+    grid['staff-b'][2] = '日' // 日勤違反 → 修正
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [dayOnlyPair], ALL_STAFF, warnings)
+
+    expect(grid['staff-a'][0]).toBe('夜')
+    expect(grid['staff-b'][0]).toBe('夜')
+    expect(grid['staff-b'][2]).toBe('')
+  })
+})
+
+// ──────────────────────────────────────────────
+// 複数ペア制約の相互作用（収束ループ）
+// ──────────────────────────────────────────────
+
+describe('validateAndFixPairConstraints — 複数ペア制約', () => {
+  it('A-B と A-C の両方が must_not_pair: 同日全員夜勤で両方の違反を解消する', () => {
+    const pairAB = makePair({ id: 'pair-ab', staff_id_a: 'staff-a', staff_id_b: 'staff-b' })
+    const pairAC = makePair({ id: 'pair-ac', staff_id_a: 'staff-a', staff_id_b: 'staff-c' })
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-b'][0] = '夜'
+    grid['staff-c'][0] = '夜'
+    // staff-d は空き → 代替候補
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [pairAB, pairAC], ALL_STAFF, warnings)
+
+    // staff-a はそのまま
+    expect(grid['staff-a'][0]).toBe('夜')
+    // staff-b と staff-c のうち少なくとも一方は解放されている
+    const bFixed = grid['staff-b'][0] === ''
+    const cFixed = grid['staff-c'][0] === ''
+    // 両方が staff-a と同日夜勤にはなっていない
+    const aViolation = (grid['staff-b'][0] === '夜' || grid['staff-c'][0] === '夜') &&
+      grid['staff-a'][0] === '夜'
+    // ペア制約 A-B と A-C が両方満たされていること
+    const abViolation = grid['staff-a'][0] === '夜' && grid['staff-b'][0] === '夜'
+    const acViolation = grid['staff-a'][0] === '夜' && grid['staff-c'][0] === '夜'
+    expect(abViolation).toBe(false)
+    expect(acViolation).toBe(false)
+    void bFixed; void cFixed; void aViolation // suppress lint
+  })
+
+  it('A-B と B-C の両方が must_not_pair: 同日全員夜勤でいずれも違反なし', () => {
+    const pairAB = makePair({ id: 'pair-ab', staff_id_a: 'staff-a', staff_id_b: 'staff-b' })
+    const pairBC = makePair({ id: 'pair-bc', staff_id_a: 'staff-b', staff_id_b: 'staff-c' })
+    const grid = emptyGrid()
+    grid['staff-a'][0] = '夜'
+    grid['staff-b'][0] = '夜'
+    grid['staff-c'][0] = '夜'
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [pairAB, pairBC], ALL_STAFF, warnings)
+
+    // 処理後に A-B, B-C のどちらも夜勤ペアでないこと
+    const nightSet = new Set(
+      ALL_STAFF.filter((s) => grid[s.id][0] === '夜').map((s) => s.id),
+    )
+    expect(nightSet.has('staff-a') && nightSet.has('staff-b')).toBe(false)
+    expect(nightSet.has('staff-b') && nightSet.has('staff-c')).toBe(false)
+  })
+
+  it('独立した2ペアが同日に別々の違反を起こす場合も両方修正する', () => {
+    // A-B と C-D が別々のペア制約
+    const pairAB = makePair({ id: 'pair-ab', staff_id_a: 'staff-a', staff_id_b: 'staff-b' })
+    const pairCD: StaffPairConstraint = {
+      id: 'pair-cd',
+      staff_id_a: 'staff-c',
+      staff_id_b: 'staff-d',
+      constraint_type: 'must_not_pair',
+      shift_type_id: null,
+      note: null,
+      created_at: '2026-01-01T00:00:00Z',
+    }
+    // 5人目のスタッフが必要（代替候補）
+    const extraStaff = [...ALL_STAFF, makeStaff('staff-e')]
+    const grid: ShiftGrid = Object.fromEntries(
+      extraStaff.map((s) => [s.id, Array(DAYS).fill('') as string[]]),
+    )
+    grid['staff-a'][1] = '夜'
+    grid['staff-b'][1] = '夜' // A-B 違反
+    grid['staff-c'][1] = '夜'
+    grid['staff-d'][1] = '夜' // C-D 違反
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [pairAB, pairCD], extraStaff, warnings)
+
+    // 両違反が解消されていること
+    expect(grid['staff-a'][1] === '夜' && grid['staff-b'][1] === '夜').toBe(false)
+    expect(grid['staff-c'][1] === '夜' && grid['staff-d'][1] === '夜').toBe(false)
+  })
+})
+
+// ──────────────────────────────────────────────
+// isWork が '明' を含むことの保証（連続勤務チェック）
+// ──────────────────────────────────────────────
+
+describe('validateAndFixPairConstraints — 連続勤務チェック（明を含む）', () => {
+  it('夜→明→日→日 の後に再充填される候補として選ばれない（maxConsecutive=4）', () => {
+    // grid: [夜, 明, 日, 日, 違反日, ...]
+    // staff-c が dayIdx=0〜3 に連続4日（夜/明/日/日）で maxConsecutive=4 の場合、
+    // dayIdx=4 には充填できない
+    const days = 7
+    const grid: ShiftGrid = Object.fromEntries(
+      ALL_STAFF.map((s) => [s.id, Array(days).fill('') as string[]]),
+    )
+    grid['staff-a'][4] = '夜'
+    grid['staff-b'][4] = '夜' // 違反
+
+    // staff-c が 0〜3 に連続4日（夜明日日）
+    grid['staff-c'][0] = '夜'
+    grid['staff-c'][1] = '明'
+    grid['staff-c'][2] = '日'
+    grid['staff-c'][3] = '日'
+    // dayIdx=4 に夜勤を入れると streak が 1（=1）... しかし '明' を isWork に含めると
+    // i=3:'日'→2, i=2:'日'→3, i=1:'明'→4, i=0:'夜'→5 → 5 > 4 → false
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings, 4)
+
+    // staff-c は連続勤務超過で候補にならない
+    expect(grid['staff-c'][4]).not.toBe('夜')
+    // staff-d が充填される
+    expect(grid['staff-d'][4]).toBe('夜')
+  })
+
+  it('夜→明 の翌日に再充填されない（前日が明けで即 L17 の前日チェックが弾く）', () => {
+    // [夜, 明, ''] の dayIdx=2: L17 で dayIdx-1='明' → false のため夜勤不可
+    const days = 5
+    const grid: ShiftGrid = Object.fromEntries(
+      ALL_STAFF.map((s) => [s.id, Array(days).fill('') as string[]]),
+    )
+    grid['staff-a'][2] = '夜'
+    grid['staff-b'][2] = '夜' // 違反
+
+    // staff-c の dayIdx=1 が '明'（前日が '夜'）
+    grid['staff-c'][0] = '夜'
+    grid['staff-c'][1] = '明'
+    // dayIdx=2 は '': canTakeNight で dayIdx-1='明' → false
+
+    const warnings: string[] = []
+    validateAndFixPairConstraints(grid, [makePair()], ALL_STAFF, warnings)
+
+    // staff-c は候補にならない（dayIdx-1 が '明'）
+    expect(grid['staff-c'][2]).not.toBe('夜')
+    // staff-d が充填される
+    expect(grid['staff-d'][2]).toBe('夜')
+  })
+})

--- a/src/lib/shift-solver-csp.ts
+++ b/src/lib/shift-solver-csp.ts
@@ -179,11 +179,11 @@ function buildDayMeta(year: number, month: number, daysInMonth: number, bathDayI
   })
 }
 
-function pairTargetsNight(pair: StaffPairConstraint): boolean {
+export function pairTargetsNight(pair: StaffPairConstraint): boolean {
   return pair.shift_type_id === null || pair.shift_type?.is_overnight === true
 }
 
-function pairTargetsDay(pair: StaffPairConstraint): boolean {
+export function pairTargetsDay(pair: StaffPairConstraint): boolean {
   return pair.shift_type_id === null || pair.shift_type?.is_overnight === false
 }
 

--- a/src/lib/shift-solver-fallback.ts
+++ b/src/lib/shift-solver-fallback.ts
@@ -1,6 +1,7 @@
 import { getDaysInMonth } from 'date-fns'
 import HolidayJP from '@holiday-jp/holiday_jp'
 import type { ShiftCode, ShiftGrid, SolverInput, SolverOutput } from './shift-solver'
+import { pairTargetsNight, pairTargetsDay } from './shift-solver-csp'
 
 function emptyGrid(staff: SolverInput['staff'], daysInMonth: number): ShiftGrid {
   return Object.fromEntries(
@@ -156,8 +157,7 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
       .filter((member) => canAssignNight(grid, member.id, dayIdx, maxConsecutive))
       .filter((member) =>
         !pairConstraints.some((pair) => {
-          if (pair.constraint_type !== 'must_not_pair') return false
-          if (pair.shift_type_id !== null && pair.shift_type?.is_overnight === false) return false
+          if (pair.constraint_type !== 'must_not_pair' || !pairTargetsNight(pair)) return false
           const partnerId =
             pair.staff_id_a === member.id ? pair.staff_id_b
             : pair.staff_id_b === member.id ? pair.staff_id_a
@@ -170,6 +170,15 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
     while (assignedNightIds.size < minNight && nightCandidates.length > 0) {
       const candidate = nightCandidates.shift()
       if (!candidate) break
+      const hasNightPairViolation = pairConstraints.some((pair) => {
+        if (pair.constraint_type !== 'must_not_pair' || !pairTargetsNight(pair)) return false
+        const partnerId =
+          pair.staff_id_a === candidate.id ? pair.staff_id_b
+          : pair.staff_id_b === candidate.id ? pair.staff_id_a
+          : null
+        return partnerId !== null && assignedNightIds.has(partnerId)
+      })
+      if (hasNightPairViolation) continue
       assignedNightIds.add(candidate.id)
       grid[candidate.id][dayIdx] = '夜'
       nightCount.set(candidate.id, (nightCount.get(candidate.id) ?? 0) + 1)
@@ -188,9 +197,7 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
     )
     const isDayPairViolation = (memberId: string) =>
       pairConstraints.some((pair) => {
-        if (pair.constraint_type !== 'must_not_pair') return false
-        if (pair.shift_type_id !== null && pair.shift_type == null) return false
-        if (pair.shift_type_id !== null && pair.shift_type?.is_overnight === true) return false
+        if (pair.constraint_type !== 'must_not_pair' || !pairTargetsDay(pair)) return false
         const partnerId =
           pair.staff_id_a === memberId ? pair.staff_id_b
           : pair.staff_id_b === memberId ? pair.staff_id_a
@@ -241,11 +248,23 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
 
       const { dayLimit } = getDayRequirements(constraints, shiftTypes, dayIdx, year, month, bathSet)
       const currentDayCount = staff.filter((candidate) => grid[candidate.id][dayIdx] === '日').length
-      if (currentDayCount < dayLimit && canAssignDay(grid, member.id, dayIdx, maxConsecutive)) {
+      const hasFillDayPairViolation = pairConstraints.some((pair) => {
+        if (pair.constraint_type !== 'must_not_pair' || !pairTargetsDay(pair)) return false
+        const partnerId =
+          pair.staff_id_a === member.id ? pair.staff_id_b
+          : pair.staff_id_b === member.id ? pair.staff_id_a
+          : null
+        return partnerId !== null && grid[partnerId]?.[dayIdx] === '日'
+      })
+      if (currentDayCount < dayLimit && canAssignDay(grid, member.id, dayIdx, maxConsecutive) && !hasFillDayPairViolation) {
         grid[member.id][dayIdx] = '日'
       } else {
         grid[member.id][dayIdx] = '公'
-        warnings.push(`${member.name}: ${dayIdx + 1}日は制約都合で公休に退避しました`)
+        if (hasFillDayPairViolation) {
+          warnings.push(`${member.name}: ${dayIdx + 1}日はペア制約のため公休に退避しました`)
+        } else {
+          warnings.push(`${member.name}: ${dayIdx + 1}日は制約都合で公休に退避しました`)
+        }
       }
     }
   }

--- a/src/lib/shift-solver-fallback.ts
+++ b/src/lib/shift-solver-fallback.ts
@@ -183,16 +183,36 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
   for (let dayIdx = 0; dayIdx < daysInMonth; dayIdx++) {
     const { requiredDay, dayLimit, isWeekend } = getDayRequirements(constraints, shiftTypes, dayIdx, year, month, bathSet)
 
+    const assignedDayIds = new Set(
+      staff.filter((s) => grid[s.id][dayIdx] === '日').map((s) => s.id),
+    )
+    const isDayPairViolation = (memberId: string) =>
+      pairConstraints.some((pair) => {
+        if (pair.constraint_type !== 'must_not_pair') return false
+        if (pair.shift_type_id !== null && pair.shift_type == null) return false
+        if (pair.shift_type_id !== null && pair.shift_type?.is_overnight === true) return false
+        const partnerId =
+          pair.staff_id_a === memberId ? pair.staff_id_b
+          : pair.staff_id_b === memberId ? pair.staff_id_a
+          : null
+        return partnerId !== null && assignedDayIds.has(partnerId)
+      })
+
     if (!isWeekend && !staff.some((member) => seniorIds.has(member.id) && grid[member.id][dayIdx] === '日')) {
       const seniorCandidate = staff
         .filter((member) => seniorIds.has(member.id))
+        .filter((member) => !isDayPairViolation(member.id))
         .find((member) => canAssignDay(grid, member.id, dayIdx, maxConsecutive))
-      if (seniorCandidate) grid[seniorCandidate.id][dayIdx] = '日'
+      if (seniorCandidate) {
+        grid[seniorCandidate.id][dayIdx] = '日'
+        assignedDayIds.add(seniorCandidate.id)
+      }
     }
 
-    let dayCount = staff.filter((member) => grid[member.id][dayIdx] === '日').length
+    let dayCount = assignedDayIds.size
     const dayCandidates = [...staff]
       .filter((member) => canAssignDay(grid, member.id, dayIdx, maxConsecutive))
+      .filter((member) => !isDayPairViolation(member.id))
       .sort((left, right) => {
         const leftOffs = grid[left.id].filter(isOff).length
         const rightOffs = grid[right.id].filter(isOff).length
@@ -201,7 +221,9 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
 
     for (const candidate of dayCandidates) {
       if (dayCount >= requiredDay || dayCount >= dayLimit) break
+      if (isDayPairViolation(candidate.id)) continue
       grid[candidate.id][dayIdx] = '日'
+      assignedDayIds.add(candidate.id)
       dayCount += 1
     }
   }

--- a/src/lib/shift-validator.ts
+++ b/src/lib/shift-validator.ts
@@ -1,0 +1,191 @@
+import type { ShiftCode, ShiftGrid } from './shift-solver'
+import type { StaffPairConstraint, StaffProfile } from '@/types'
+import { pairTargetsNight, pairTargetsDay } from './shift-solver-csp'
+
+// '明'（夜勤明け）は翌日の勤務扱いとして連続勤務カウントに含める
+function isWork(code: string): boolean {
+  return code === '日' || code === '夜' || code === '明'
+}
+
+function canTakeNight(
+  grid: ShiftGrid,
+  staffId: string,
+  dayIdx: number,
+  daysInMonth: number,
+  maxConsecutive: number,
+): boolean {
+  if (grid[staffId][dayIdx] !== '') return false
+  if (dayIdx > 0 && (grid[staffId][dayIdx - 1] === '夜' || grid[staffId][dayIdx - 1] === '明')) return false
+  if (dayIdx + 1 < daysInMonth && grid[staffId][dayIdx + 1] !== '') return false
+  if (dayIdx + 2 < daysInMonth && grid[staffId][dayIdx + 2] !== '') return false
+
+  let streak = 1
+  for (let i = dayIdx - 1; i >= 0; i--) {
+    if (isWork(grid[staffId][i])) streak += 1
+    else break
+  }
+  return streak <= maxConsecutive
+}
+
+function canTakeDay(
+  grid: ShiftGrid,
+  staffId: string,
+  dayIdx: number,
+  daysInMonth: number,
+  maxConsecutive: number,
+): boolean {
+  if (grid[staffId][dayIdx] !== '') return false
+  if (dayIdx > 0 && (grid[staffId][dayIdx - 1] === '夜' || grid[staffId][dayIdx - 1] === '明')) return false
+  if (dayIdx + 1 < daysInMonth && grid[staffId][dayIdx + 1] === '夜') return false
+
+  let before = 0
+  for (let i = dayIdx - 1; i >= 0; i--) {
+    if (isWork(grid[staffId][i])) before += 1
+    else break
+  }
+  let after = 0
+  for (let i = dayIdx + 1; i < daysInMonth; i++) {
+    if (isWork(grid[staffId][i])) after += 1
+    else break
+  }
+  return before + 1 + after <= maxConsecutive
+}
+
+function hasNightPairConflict(
+  candidateId: string,
+  pairConstraints: StaffPairConstraint[],
+  assignedIds: Set<string>,
+): boolean {
+  return pairConstraints.some((pair) => {
+    if (pair.constraint_type !== 'must_not_pair' || !pairTargetsNight(pair)) return false
+    const partnerId =
+      pair.staff_id_a === candidateId ? pair.staff_id_b
+      : pair.staff_id_b === candidateId ? pair.staff_id_a
+      : null
+    return partnerId !== null && assignedIds.has(partnerId)
+  })
+}
+
+function hasDayPairConflict(
+  candidateId: string,
+  pairConstraints: StaffPairConstraint[],
+  assignedIds: Set<string>,
+): boolean {
+  return pairConstraints.some((pair) => {
+    if (pair.constraint_type !== 'must_not_pair' || !pairTargetsDay(pair)) return false
+    const partnerId =
+      pair.staff_id_a === candidateId ? pair.staff_id_b
+      : pair.staff_id_b === candidateId ? pair.staff_id_a
+      : null
+    return partnerId !== null && assignedIds.has(partnerId)
+  })
+}
+
+/**
+ * must_not_pair 制約違反をグリッドから検出・修正する後処理バリデーター。
+ *
+ * CSP/フォールバック後に呼び出す。複数ペア制約が存在するとき修正が相互に影響する可能性があるため、
+ * 違反がなくなるか MAX_PASSES に達するまでスキャンを繰り返す（収束ループ）。
+ *
+ * 各違反に対して:
+ *   1. staff_id_b のシフトを解放（夜勤なら '明'・'公' も解放）
+ *   2. 代替スタッフを探して再充填（連続勤務チェック込み）
+ *   3. 代替不能なら警告のみ（空きスロットのまま）
+ *
+ * '公' への強制変更は行わない。
+ */
+export function validateAndFixPairConstraints(
+  grid: ShiftGrid,
+  pairConstraints: StaffPairConstraint[],
+  staff: StaffProfile[],
+  warnings: string[],
+  maxConsecutive = 5,
+): void {
+  if (staff.length === 0) return
+  const daysInMonth = grid[staff[0].id]?.length ?? 0
+  if (daysInMonth === 0) return
+
+  const staffById = new Map(staff.map((s) => [s.id, s]))
+  const mustNotPairs = pairConstraints.filter((p) => p.constraint_type === 'must_not_pair')
+  if (mustNotPairs.length === 0) return
+
+  // 複数ペア制約が相互に影響するため収束ループで繰り返す
+  const MAX_PASSES = mustNotPairs.length + 1
+
+  for (let pass = 0; pass < MAX_PASSES; pass++) {
+    let anyFixed = false
+
+    for (const pair of mustNotPairs) {
+      for (let dayIdx = 0; dayIdx < daysInMonth; dayIdx++) {
+        const aShift = grid[pair.staff_id_a]?.[dayIdx]
+        const bShift = grid[pair.staff_id_b]?.[dayIdx]
+
+        // スタッフ不在（undefined）・未割当（''）のいずれも違反対象外としてスキップ
+        if (aShift === undefined || aShift === '' || bShift === undefined || bShift === '') continue
+
+        const nightViolation = pairTargetsNight(pair) && aShift === '夜' && bShift === '夜'
+        const dayViolation = pairTargetsDay(pair) && aShift === '日' && bShift === '日'
+        if (!nightViolation && !dayViolation) continue
+
+        const violationCode: '夜' | '日' = nightViolation ? '夜' : '日'
+        const bName = staffById.get(pair.staff_id_b)?.name ?? pair.staff_id_b
+
+        // 解放: staff_id_b のシフトを未割当に戻す
+        grid[pair.staff_id_b][dayIdx] = ''
+        if (violationCode === '夜') {
+          // '明' は夜勤由来で確実に自動挿入されたもの
+          if (dayIdx + 1 < daysInMonth && grid[pair.staff_id_b][dayIdx + 1] === '明') {
+            grid[pair.staff_id_b][dayIdx + 1] = ''
+          }
+          // '公' は夜勤後の自動挿入が疑われる場合のみ解放
+          // 他の理由（定休・手動）で入っている '公' と区別できないため、
+          // === '公' の場合のみ解放する（誤解放リスクは設計上の限界として許容）
+          if (dayIdx + 2 < daysInMonth && grid[pair.staff_id_b][dayIdx + 2] === '公') {
+            grid[pair.staff_id_b][dayIdx + 2] = ''
+          }
+        }
+
+        // 再充填: staff_id_a/b 以外で条件を満たすスタッフを探す
+        // assignedOnDay は解放後の最新グリッド状態から構築する
+        const assignedOnDay = new Set(
+          staff
+            .filter((m) => m.id !== pair.staff_id_a && m.id !== pair.staff_id_b && grid[m.id]?.[dayIdx] === violationCode)
+            .map((m) => m.id),
+        )
+        // staff_id_a は違反の保持側として含める（候補のペア制約チェック用）
+        assignedOnDay.add(pair.staff_id_a)
+
+        const replacement = staff
+          .filter((m) => m.id !== pair.staff_id_a && m.id !== pair.staff_id_b)
+          .find((m) => {
+            if (violationCode === '夜') {
+              return (
+                canTakeNight(grid, m.id, dayIdx, daysInMonth, maxConsecutive) &&
+                !hasNightPairConflict(m.id, pairConstraints, assignedOnDay)
+              )
+            }
+            return (
+              canTakeDay(grid, m.id, dayIdx, daysInMonth, maxConsecutive) &&
+              !hasDayPairConflict(m.id, pairConstraints, assignedOnDay)
+            )
+          })
+
+        if (replacement) {
+          grid[replacement.id][dayIdx] = violationCode as ShiftCode
+          if (violationCode === '夜') {
+            if (dayIdx + 1 < daysInMonth) grid[replacement.id][dayIdx + 1] = '明'
+            if (dayIdx + 2 < daysInMonth && grid[replacement.id][dayIdx + 2] === '') grid[replacement.id][dayIdx + 2] = '公'
+          }
+          const rName = staffById.get(replacement.id)?.name ?? replacement.id
+          warnings.push(`ペア制約後処理: ${dayIdx + 1}日 ${bName} を解放し ${rName} へ再充填しました`)
+        } else {
+          warnings.push(`ペア制約後処理: ${dayIdx + 1}日 ${bName} を解放しましたが代替スタッフが見つかりませんでした`)
+        }
+
+        anyFixed = true
+      }
+    }
+
+    if (!anyFixed) break
+  }
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from 'vitest/config'
+import path from 'path'
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    globals: true,
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+    },
+  },
+})


### PR DESCRIPTION
## Summary

- CSP・フォールバック両経路で生じうる `must_not_pair` 制約違反を、シフト生成後に一括検出・修正するバリデーター層を追加
- フォールバックソルバー内の夜勤・日勤ペア制約バグを修正
- Vitest による回帰テストを整備（計32テスト）

## Changes

### 新規ファイル

| ファイル | 内容 |
|----------|------|
| `src/lib/shift-validator.ts` | `validateAndFixPairConstraints` 後処理バリデーター |
| `src/lib/__tests__/shift-validator.test.ts` | バリデーター18ケースの回帰テスト |

### 変更ファイル

| ファイル | 変更内容 |
|----------|----------|
| `src/app/api/shift/generate/route.ts` | CSP/フォールバック後にバリデーターを呼び出し |
| `src/lib/shift-solver-fallback.ts` | 夜勤ループ内のペア制約再チェック追加、日勤最終充填ループのペア制約チェック追加 |
| `src/lib/shift-solver-csp.ts` | `pairTargetsNight` / `pairTargetsDay` を `export` に変更 |

## Validator 設計

```
違反検出 → staff_id_b を解放（夜勤なら '明'・'公' も解放）→ 代替スタッフで再充填
```

- 複数ペア制約の相互影響に対応するため収束ループを実装（MAX_PASSES = ペア数 + 1）
- `'明'`（夜勤明け）を連続勤務日数カウントに含める
- 代替スタッフが見つからない場合は警告のみ（空きスロットのまま）
- `'公'` への強制変更は行わない（労務制約違反・必要人員不足を誘発するため）

## Test plan

- [ ] `npm test` で全32テストがパスすることを確認
- [ ] シフト生成画面で must_not_pair 制約を設定してシフト生成 → ペア同士が同日同シフトにならないことを確認
- [ ] フォールバック経由（CSP失敗時）でも制約が守られることを確認
- [ ] 代替スタッフなしのケースで警告メッセージが表示されることを確認