### PR TITLE
feat: 病院独自の休日（開院記念日など）をシフト生成に反映する

### DIFF
--- a/src/app/(app)/constraints/page.tsx
+++ b/src/app/(app)/constraints/page.tsx
@@ -3,12 +3,12 @@
 import { useState, useEffect } from 'react'
 import { format, addMonths } from 'date-fns'
 import { ja } from 'date-fns/locale'
-import { Plus, X, CheckCircle2, XCircle, CalendarDays, Shield } from 'lucide-react'
+import { Plus, X, CheckCircle2, XCircle, CalendarDays, Shield, Calendar } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Label } from '@/components/ui/label'
 import { Checkbox } from '@/components/ui/checkbox'
-import { StaffProfile, ShiftType, StaffPairConstraint, PairConstraintType } from '@/types'
+import { StaffProfile, ShiftType, StaffPairConstraint, PairConstraintType, CustomHoliday } from '@/types'
 import { PairConstraintDialog, PairConstraintFormData } from '@/components/features/constraints/PairConstraintDialog'
 import { createClient } from '@/lib/supabase/client'
 
@@ -77,6 +77,9 @@ export default function ConstraintsPage() {
   const [pairDialogOpen, setPairDialogOpen] = useState(false)
   const [saved, setSaved] = useState(false)
   const [loading, setLoading] = useState(false)
+  const [customHolidays, setCustomHolidays] = useState<CustomHoliday[]>([])
+  const [newHolidayDate, setNewHolidayDate] = useState('')
+  const [newHolidayName, setNewHolidayName] = useState('')
 
   // スタッフ・シフト種別・ペア制約は月に関係なく一度だけ取得
   useEffect(() => {
@@ -91,6 +94,18 @@ export default function ConstraintsPage() {
       if (pairData) setPairs(pairData)
     }
     loadMasters()
+  }, [])
+
+  // カスタム休日は月に関係なく全件取得
+  useEffect(() => {
+    async function loadCustomHolidays() {
+      const { data } = await supabase
+        .from('custom_holidays')
+        .select('*')
+        .order('date')
+      if (data) setCustomHolidays(data as CustomHoliday[])
+    }
+    loadCustomHolidays()
   }, [])
 
   // 月が変わるたびに制約を読み込む
@@ -180,6 +195,37 @@ export default function ConstraintsPage() {
   async function handleDeletePair(id: string) {
     await supabase.from('staff_pair_constraints').delete().eq('id', id)
     setPairs((prev) => prev.filter((p) => p.id !== id))
+  }
+
+  async function handleAddCustomHoliday() {
+    if (!newHolidayDate || !newHolidayName.trim()) return
+    const { data, error } = await supabase
+      .from('custom_holidays')
+      .insert({ date: newHolidayDate, name: newHolidayName.trim() })
+      .select()
+      .single()
+    if (error) {
+      if (error.code === '23505') {
+        alert('この日付はすでに登録されています')
+      } else {
+        alert('登録に失敗しました')
+      }
+      return
+    }
+    if (data) {
+      const { data: refreshed } = await supabase
+        .from('custom_holidays')
+        .select('*')
+        .order('date')
+      if (refreshed) setCustomHolidays(refreshed as CustomHoliday[])
+      setNewHolidayDate('')
+      setNewHolidayName('')
+    }
+  }
+
+  async function handleDeleteCustomHoliday(id: string) {
+    await supabase.from('custom_holidays').delete().eq('id', id)
+    setCustomHolidays((prev) => prev.filter((h) => h.id !== id))
   }
 
   function setMinStaffingField(key: keyof MinStaffing, val: number) {
@@ -397,6 +443,66 @@ export default function ConstraintsPage() {
                 </div>
               )
             })}
+          </div>
+        )}
+      </section>
+
+      {/* カスタム休日 */}
+      <section className="rounded-xl border border-rose-100 bg-white p-5 space-y-4">
+        <div className="flex items-center gap-2">
+          <Calendar className="h-4 w-4 text-rose-400 shrink-0" />
+          <h2 className="text-sm font-semibold text-gray-700">カスタム休日（開院記念日・院内行事など）</h2>
+        </div>
+        {/* 追加フォーム */}
+        <div className="flex items-center gap-2 flex-wrap">
+          <Input
+            type="date"
+            value={newHolidayDate}
+            onChange={(e) => setNewHolidayDate(e.target.value)}
+            className="w-40"
+            aria-label="休日の日付"
+          />
+          <Input
+            type="text"
+            placeholder="例: 開院記念日"
+            value={newHolidayName}
+            onChange={(e) => setNewHolidayName(e.target.value)}
+            className="w-48"
+            aria-label="休日の名称"
+            onKeyDown={(e) => { if (e.key === 'Enter') handleAddCustomHoliday() }}
+          />
+          <button
+            onClick={handleAddCustomHoliday}
+            disabled={!newHolidayDate || !newHolidayName.trim()}
+            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-semibold text-rose-600 border border-rose-300 rounded-lg hover:bg-rose-50 transition-colors disabled:opacity-40 disabled:cursor-not-allowed"
+            aria-label="カスタム休日を追加"
+          >
+            <Plus className="h-3.5 w-3.5" />追加
+          </button>
+        </div>
+        {/* 一覧 */}
+        {customHolidays.length === 0 ? (
+          <p className="text-sm text-gray-400 py-4 text-center">カスタム休日が設定されていません</p>
+        ) : (
+          <div className="space-y-2">
+            {customHolidays.map((holiday) => (
+              <div
+                key={holiday.id}
+                className="flex items-center justify-between px-3 py-2.5 rounded-lg border border-red-200 bg-red-50"
+              >
+                <div className="flex items-center gap-3 text-sm text-gray-700">
+                  <span className="font-mono text-gray-500">{holiday.date}</span>
+                  <span className="font-medium">{holiday.name}</span>
+                </div>
+                <button
+                  onClick={() => handleDeleteCustomHoliday(holiday.id)}
+                  className="text-gray-400 hover:text-red-400 transition-colors ml-2"
+                  aria-label={`${holiday.name}を削除`}
+                >
+                  <X className="h-4 w-4" />
+                </button>
+              </div>
+            ))}
           </div>
         )}
       </section>

--- a/src/app/(app)/shift-table/page.tsx
+++ b/src/app/(app)/shift-table/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useMemo, useEffect, useRef } from 'react'
-import { getDaysInMonth, getDay, addMonths, startOfMonth } from 'date-fns'
+import { getDaysInMonth, getDay, addMonths, startOfMonth, format } from 'date-fns'
 import HolidayJP from '@holiday-jp/holiday_jp'
 import { useReactToPrint } from 'react-to-print'
 import {
@@ -11,7 +11,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { StaffProfile, deriveWorkHoursType } from '@/types'
+import { StaffProfile, deriveWorkHoursType, CustomHoliday } from '@/types'
 import { ConstraintSummary } from '@/components/features/constraints/ConstraintSummary'
 import { createClient } from '@/lib/supabase/client'
 
@@ -104,6 +104,7 @@ export default function ShiftTablePage() {
   const [carryOverMap, setCarryOverMap] = useState<Record<string, number>>({})
   const [shiftPrefMap, setShiftPrefMap] = useState<Record<string, string>>({})
   const [loading, setLoading] = useState(true)
+  const [customHolidayDates, setCustomHolidayDates] = useState<string[]>([])
   const handlePrint = useReactToPrint({ contentRef: printRef, documentTitle: `シフト表_${selectedMonth}` })
 
   useEffect(() => {
@@ -125,6 +126,23 @@ export default function ShiftTablePage() {
       if (stored) setBathDaysDow(JSON.parse(stored))
     } catch {}
   }, [])
+
+  // 選択月が変わるたびに当月のカスタム休日を取得
+  useEffect(() => {
+    async function loadCustomHolidays() {
+      const monthStart = `${selectedMonth}-01`
+      const [year, month] = selectedMonth.split('-').map(Number)
+      const lastDay = getDaysInMonth(new Date(year, month - 1))
+      const monthEnd = `${selectedMonth}-${String(lastDay).padStart(2, '0')}`
+      const { data } = await supabase
+        .from('custom_holidays')
+        .select('date')
+        .gte('date', monthStart)
+        .lte('date', monthEnd)
+      if (data) setCustomHolidayDates((data as Pick<CustomHoliday, 'date'>[]).map((h) => h.date))
+    }
+    loadCustomHolidays()
+  }, [selectedMonth])
 
   useEffect(() => {
     async function loadShifts() {
@@ -208,7 +226,7 @@ export default function ShiftTablePage() {
         dow,
         dateStr,
         isBath: bathSet.has(dateStr) || bathDaysDow.includes(dow),
-        isHoliday: HolidayJP.isHoliday(date),
+        isHoliday: HolidayJP.isHoliday(date) || customHolidayDates.includes(format(date, 'yyyy-MM-dd')),
       }
     })
     const rows: StaffRow[] = staffList.map((staff) => {
@@ -222,7 +240,7 @@ export default function ShiftTablePage() {
       }
     })
     return { days, rows }
-  }, [selectedMonth, staffList, shiftMap, bathSet, bathDaysDow, carryOverMap])
+  }, [selectedMonth, staffList, shiftMap, bathSet, bathDaysDow, carryOverMap, customHolidayDates])
 
   const dailyCounts = useMemo(() => {
     return days.map((_, i) => {

--- a/src/app/api/shift/generate/route.ts
+++ b/src/app/api/shift/generate/route.ts
@@ -75,6 +75,7 @@ export async function POST(request: Request) {
     { data: shiftTypes },
     { data: prevTailRaw },
     { data: carryOversRaw },
+    { data: customHolidaysRaw },
   ] = await Promise.all([
     supabase.from('staff_profiles').select('*').eq('is_active', true).order('sort_order').order('created_at'),
     supabase.from('shift_constraints').select('*').eq('year_month', year_month).maybeSingle(),
@@ -85,6 +86,7 @@ export async function POST(request: Request) {
     tailFromBody ? Promise.resolve({ data: null }) :
       supabase.from('shift_assignments').select('staff_id, shift_code, date').in('date', [prevSecondLast, prevLastDay]),
     supabase.from('staff_carry_overs').select('staff_id, carry_over_days').eq('to_month', year_month),
+    supabase.from('custom_holidays').select('date').gte('date', monthStart).lte('date', monthEnd),
   ])
 
   const prevMonthTail: TailEntry[] = tailFromBody ?? (prevTailRaw ?? []).map((r) => ({
@@ -126,6 +128,7 @@ export async function POST(request: Request) {
     bathDayIndices,
     prevMonthTail,
     carryOverByStaff,
+    customHolidayDates: (customHolidaysRaw ?? []).map((h) => h.date as string),
   }
 
   let { grid, warnings, targetOffDays, solverStatus } = await generateShifts(solverInput)

--- a/src/lib/shift-solver-csp.ts
+++ b/src/lib/shift-solver-csp.ts
@@ -18,6 +18,8 @@ export interface SolverInput {
   prevMonthTail?: { staff_id: string; shift_code: string; day: number }[]
   /** スタッフIDごとの前月繰越日数 */
   carryOverByStaff?: Record<string, number>
+  /** カスタム休日の日付文字列（'YYYY-MM-DD'[]）。isWeekend 判定に使用する */
+  customHolidayDates?: string[]
 }
 
 export interface SolverOutput {
@@ -170,12 +172,24 @@ function buildFixedLeaveData(leaveRequests: LeaveRequest[], year: number, month:
   return { fixedLeaveCodes, shiftPreferences, paidLeaveCount }
 }
 
-function buildDayMeta(year: number, month: number, daysInMonth: number, bathDayIndices: number[]): DayMeta[] {
+function buildDayMeta(
+  year: number,
+  month: number,
+  daysInMonth: number,
+  bathDayIndices: number[],
+  customHolidayDates?: string[],
+): DayMeta[] {
   const bathSet = new Set(bathDayIndices)
+  const customHolidaySet = new Set(customHolidayDates ?? [])
   return Array.from({ length: daysInMonth }, (_, dayIdx) => {
     const date = new Date(year, month - 1, dayIdx + 1)
+    const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx + 1).padStart(2, '0')}`
     return {
-      isWeekend: date.getDay() === 0 || date.getDay() === 6 || HolidayJP.isHoliday(date),
+      isWeekend:
+        date.getDay() === 0 ||
+        date.getDay() === 6 ||
+        HolidayJP.isHoliday(date) ||
+        customHolidaySet.has(dateStr),
       isBathDay: bathSet.has(dayIdx),
     }
   })
@@ -454,13 +468,13 @@ function checkFeasibility(
 }
 
 export async function generateShifts(input: SolverInput): Promise<SolverOutput> {
-  const { yearMonth, staff, constraints, leaveRequests, pairConstraints, shiftTypes, bathDayIndices, prevMonthTail } = input
+  const { yearMonth, staff, constraints, leaveRequests, pairConstraints, shiftTypes, bathDayIndices, prevMonthTail, customHolidayDates } = input
   const warnings: string[] = []
 
   const [year, month] = yearMonth.split('-').map(Number)
   const daysInMonth = getDaysInMonth(new Date(year, month - 1))
   const grid = emptyGrid(staff, daysInMonth)
-  const dayMeta = buildDayMeta(year, month, daysInMonth, bathDayIndices)
+  const dayMeta = buildDayMeta(year, month, daysInMonth, bathDayIndices, customHolidayDates)
   const targetOffDays = constraints?.target_off_days ?? dayMeta.filter(d => d.isWeekend).length
   const { forcedAkeDays, fixedOffDays, carryInWorkDays } = buildPrevMonthInfo(staff, prevMonthTail, daysInMonth)
   const { fixedLeaveCodes, shiftPreferences, paidLeaveCount } = buildFixedLeaveData(leaveRequests, year, month)
@@ -474,9 +488,11 @@ export async function generateShifts(input: SolverInput): Promise<SolverOutput> 
       if (!member.allow_extra_off_days) {
         const hardOffDow = new Set(member.hard_off_days_of_week ?? [])
         const softOffDow = new Set(member.soft_off_days_of_week ?? [])
+        const customHolidaySet = new Set(customHolidayDates ?? [])
         const definedOffCount = Array.from({ length: daysInMonth }, (_, dayIdx) => {
           const date = new Date(year, month - 1, dayIdx + 1)
-          const isHoliday = HolidayJP.isHoliday(date)
+          const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx + 1).padStart(2, '0')}`
+          const isHoliday = HolidayJP.isHoliday(date) || customHolidaySet.has(dateStr)
           return (
             hardOffDow.has(date.getDay()) ||
             softOffDow.has(date.getDay()) ||
@@ -602,7 +618,8 @@ export async function generateShifts(input: SolverInput): Promise<SolverOutput> 
       )
 
       const date = new Date(year, month - 1, dayIdx + 1)
-      const isHoliday = HolidayJP.isHoliday(date)
+      const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx + 1).padStart(2, '0')}`
+      const isHoliday = HolidayJP.isHoliday(date) || (customHolidayDates ?? []).includes(dateStr)
       const pref = memberPrefs?.get(dayIdx)
       const isHardOffDay =
         hardOffDow.has(date.getDay()) || (member.hard_off_on_holidays && isHoliday)
@@ -628,7 +645,8 @@ export async function generateShifts(input: SolverInput): Promise<SolverOutput> 
       //   - また連休各日から重複して同じ変数に負の係数が累積するのを防ぐ
       const prevDayHardOff = dayIdx > 0 ? (() => {
         const pd = new Date(year, month - 1, dayIdx)
-        return hardOffDow.has(pd.getDay()) || (member.hard_off_on_holidays && HolidayJP.isHoliday(pd))
+        const pdStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx).padStart(2, '0')}`
+        return hardOffDow.has(pd.getDay()) || (member.hard_off_on_holidays && (HolidayJP.isHoliday(pd) || (customHolidayDates ?? []).includes(pdStr)))
       })() : false
       const prevDayForcedOff = dayIdx > 0 && (
         memberFixedLeaves?.has(dayIdx - 1) === true ||
@@ -644,9 +662,10 @@ export async function generateShifts(input: SolverInput): Promise<SolverOutput> 
         // n[X-2] も夜勤不可になるため重複誘導を防ぐ。
         if (isHardOffDay && member.max_night_shifts > 0 && dayIdx >= 2 && !prevDayForcedOff) {
           const prevPrevDate = new Date(year, month - 1, dayIdx - 1)
+          const prevPrevDateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx - 1).padStart(2, '0')}`
           const prevPrevDayHardOff =
             hardOffDow.has(prevPrevDate.getDay()) ||
-            (member.hard_off_on_holidays && HolidayJP.isHoliday(prevPrevDate))
+            (member.hard_off_on_holidays && (HolidayJP.isHoliday(prevPrevDate) || (customHolidayDates ?? []).includes(prevPrevDateStr)))
           const prevPrevDayForcedOff =
             memberFixedLeaves?.has(dayIdx - 2) === true ||
             memberFixedOff.has(dayIdx - 2) ||
@@ -669,16 +688,18 @@ export async function generateShifts(input: SolverInput): Promise<SolverOutput> 
         // 連続soft定休の初日のみ誘導（重複誘導防止）
         const prevDaySoftOff = dayIdx > 0 ? (() => {
           const pd = new Date(year, month - 1, dayIdx)
-          const pdHoliday = HolidayJP.isHoliday(pd)
+          const pdStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx).padStart(2, '0')}`
+          const pdHoliday = HolidayJP.isHoliday(pd) || (customHolidayDates ?? []).includes(pdStr)
           return softOffDow.has(pd.getDay()) || (member.soft_off_on_holidays && pdHoliday)
         })() : false
         if (member.max_night_shifts > 0 && dayIdx >= 2 && !prevDayForcedOff && !prevDaySoftOff) {
           const prevPrevDate = new Date(year, month - 1, dayIdx - 1)
+          const prevPrevDateStr2 = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx - 1).padStart(2, '0')}`
           const prevPrevDayForcedOff =
             memberFixedLeaves?.has(dayIdx - 2) === true ||
             memberFixedOff.has(dayIdx - 2) ||
             hardOffDow.has(prevPrevDate.getDay()) ||
-            (member.hard_off_on_holidays && HolidayJP.isHoliday(prevPrevDate))
+            (member.hard_off_on_holidays && (HolidayJP.isHoliday(prevPrevDate) || (customHolidayDates ?? []).includes(prevPrevDateStr2)))
           if (!prevPrevDayForcedOff) {
             if (!isSenior) {
               addObjective(varName('n', member.id, dayIdx - 2), -3)

--- a/src/lib/shift-solver-fallback.ts
+++ b/src/lib/shift-solver-fallback.ts
@@ -76,9 +76,15 @@ function getDayRequirements(
   year: number,
   month: number,
   bathSet: Set<number>,
+  customHolidayDates?: string[],
 ) {
   const date = new Date(year, month - 1, dayIdx + 1)
-  const isWeekend = date.getDay() === 0 || date.getDay() === 6 || HolidayJP.isHoliday(date)
+  const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx + 1).padStart(2, '0')}`
+  const isWeekend =
+    date.getDay() === 0 ||
+    date.getDay() === 6 ||
+    HolidayJP.isHoliday(date) ||
+    (customHolidayDates ?? []).includes(dateStr)
   const nightShiftType = shiftTypes?.find((shiftType) => shiftType.is_overnight && !shiftType.is_off)
   const dayShiftType = shiftTypes?.find((shiftType) => !shiftType.is_overnight && !shiftType.is_off)
   const dayKey = dayShiftType?.name ?? '日勤'
@@ -96,13 +102,19 @@ function getDayRequirements(
   return { requiredDay, dayLimit, minNight, isWeekend }
 }
 
-function isWeekdayDate(year: number, month: number, dayIdx: number): boolean {
+function isWeekdayDate(year: number, month: number, dayIdx: number, customHolidayDates?: string[]): boolean {
   const date = new Date(year, month - 1, dayIdx + 1)
-  return date.getDay() !== 0 && date.getDay() !== 6 && !HolidayJP.isHoliday(date)
+  const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx + 1).padStart(2, '0')}`
+  return (
+    date.getDay() !== 0 &&
+    date.getDay() !== 6 &&
+    !HolidayJP.isHoliday(date) &&
+    !(customHolidayDates ?? []).includes(dateStr)
+  )
 }
 
 export async function generateShiftsFallback(input: SolverInput): Promise<SolverOutput> {
-  const { yearMonth, staff, constraints, leaveRequests, pairConstraints, shiftTypes, bathDayIndices, prevMonthTail } = input
+  const { yearMonth, staff, constraints, leaveRequests, pairConstraints, shiftTypes, bathDayIndices, prevMonthTail, customHolidayDates } = input
   const warnings: string[] = ['⚠️ 制約ソルバーで解けなかったため、ベストエフォートで生成しました']
 
   const [year, month] = yearMonth.split('-').map(Number)
@@ -168,7 +180,9 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
     for (let dayIdx = 0; dayIdx < daysInMonth; dayIdx++) {
       if (grid[member.id][dayIdx] !== '') continue
       const date = new Date(year, month - 1, dayIdx + 1)
-      if (hardOffDow.has(date.getDay()) || (member.hard_off_on_holidays && HolidayJP.isHoliday(date))) {
+      const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx + 1).padStart(2, '0')}`
+      const isHoliday = HolidayJP.isHoliday(date) || (customHolidayDates ?? []).includes(dateStr)
+      if (hardOffDow.has(date.getDay()) || (member.hard_off_on_holidays && isHoliday)) {
         grid[member.id][dayIdx] = '公'
       }
     }
@@ -181,7 +195,7 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
 
   // Phase 2: 夜勤アサイン（D+2の公休は後処理で付与）
   for (let dayIdx = 0; dayIdx < daysInMonth; dayIdx++) {
-    const { minNight, isWeekend } = getDayRequirements(constraints, shiftTypes, dayIdx, year, month, bathSet)
+    const { minNight, isWeekend } = getDayRequirements(constraints, shiftTypes, dayIdx, year, month, bathSet, customHolidayDates)
     const assignedNightIds = new Set<string>()
     staff.forEach((member) => {
       if (grid[member.id][dayIdx] === '夜') assignedNightIds.add(member.id)
@@ -212,7 +226,7 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
           if (!otherSeniorCanCoverToday) return false
         }
         // D+2（公休予定日）が平日なら、他シニアがカバーできるかチェック
-        if (dayIdx + 2 < daysInMonth && isWeekdayDate(year, month, dayIdx + 2)) {
+        if (dayIdx + 2 < daysInMonth && isWeekdayDate(year, month, dayIdx + 2, customHolidayDates)) {
           const otherSeniorCanCoverPostNight = staff.some(
             (s) => s.id !== member.id && seniorIds.has(s.id) &&
               (grid[s.id][dayIdx + 2] === '日' || canAssignDay(grid, s.id, dayIdx + 2, maxConsecutive)),
@@ -254,7 +268,7 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
           )
           if (!otherSeniorCanCoverToday) continue
         }
-        if (dayIdx + 2 < daysInMonth && isWeekdayDate(year, month, dayIdx + 2)) {
+        if (dayIdx + 2 < daysInMonth && isWeekdayDate(year, month, dayIdx + 2, customHolidayDates)) {
           const otherSeniorCanCoverPostNight = staff.some(
             (s) => s.id !== candidate.id && seniorIds.has(s.id) &&
               (grid[s.id][dayIdx + 2] === '日' || canAssignDay(grid, s.id, dayIdx + 2, maxConsecutive)),
@@ -309,7 +323,7 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
   const carryOverByStaff = input.carryOverByStaff ?? {}
   let fallbackStatus: SolverOutput['solverStatus'] = 'success'
   for (let dayIdx = 0; dayIdx < daysInMonth; dayIdx++) {
-    const { requiredDay, dayLimit, isWeekend } = getDayRequirements(constraints, shiftTypes, dayIdx, year, month, bathSet)
+    const { requiredDay, dayLimit, isWeekend } = getDayRequirements(constraints, shiftTypes, dayIdx, year, month, bathSet, customHolidayDates)
 
     if (!isWeekend && !staff.some((member) => seniorIds.has(member.id) && grid[member.id][dayIdx] === '日')) {
       const seniorCandidate = staff
@@ -357,7 +371,7 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
         continue
       }
 
-      const { dayLimit } = getDayRequirements(constraints, shiftTypes, dayIdx, year, month, bathSet)
+      const { dayLimit } = getDayRequirements(constraints, shiftTypes, dayIdx, year, month, bathSet, customHolidayDates)
       const currentDayCount = staff.filter((candidate) => grid[candidate.id][dayIdx] === '日').length
       if (currentDayCount < dayLimit && canAssignDay(grid, member.id, dayIdx, maxConsecutive)) {
         grid[member.id][dayIdx] = '日'
@@ -392,7 +406,12 @@ export async function generateShiftsFallback(input: SolverInput): Promise<Solver
     const ngSet = new Set<string>(['公', '夜', '明'])
     for (let dayIdx = 0; dayIdx < daysInMonth; dayIdx++) {
       const date = new Date(year, month - 1, dayIdx + 1)
-      const isWeekendOrHoliday = date.getDay() === 0 || date.getDay() === 6 || HolidayJP.isHoliday(date)
+      const dateStr = `${year}-${String(month).padStart(2, '0')}-${String(dayIdx + 1).padStart(2, '0')}`
+      const isWeekendOrHoliday =
+        date.getDay() === 0 ||
+        date.getDay() === 6 ||
+        HolidayJP.isHoliday(date) ||
+        (customHolidayDates ?? []).includes(dateStr)
       if (isWeekendOrHoliday) continue
       const a = grid[pair.staff_id_a]?.[dayIdx]
       const b = grid[pair.staff_id_b]?.[dayIdx]

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -144,6 +144,17 @@ export interface StaffCarryOver {
 }
 
 // =============================
+// カスタム休日
+// =============================
+export interface CustomHoliday {
+  id: string
+  /** YYYY-MM-DD */
+  date: string
+  name: string
+  created_at: string
+}
+
+// =============================
 // シフト割り当て
 // =============================
 export interface ScheduleMonth {

--- a/supabase/migrations/20260610000000_add_custom_holidays.sql
+++ b/supabase/migrations/20260610000000_add_custom_holidays.sql
@@ -1,0 +1,27 @@
+-- UPDATE ポリシーは意図的に除外。日付・名称の変更は DELETE + INSERT で行う運用とする
+CREATE TABLE IF NOT EXISTS public.custom_holidays (
+  id          uuid        PRIMARY KEY DEFAULT gen_random_uuid(),
+  date        date        NOT NULL,
+  name        text        NOT NULL DEFAULT '' CHECK (name <> ''),
+  created_at  timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS unique_custom_holiday_date
+  ON public.custom_holidays (date);
+
+CREATE INDEX IF NOT EXISTS idx_custom_holidays_date
+  ON public.custom_holidays (date);
+
+ALTER TABLE public.custom_holidays ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "authenticated users can read custom_holidays"
+  ON public.custom_holidays FOR SELECT
+  TO authenticated USING (true);
+
+CREATE POLICY "authenticated users can insert custom_holidays"
+  ON public.custom_holidays FOR INSERT
+  TO authenticated WITH CHECK (true);
+
+CREATE POLICY "authenticated users can delete custom_holidays"
+  ON public.custom_holidays FOR DELETE
+  TO authenticated USING (true);


### PR DESCRIPTION
## Summary

- `custom_holidays` テーブルを追加し、病院独自の休日（開院記念日など）を管理できるようにした
- CSP・フォールバックソルバー両方で `customHolidayDates` を `isWeekend` 判定に適用し、シニアペア制約をスキップ
- `/api/shift/generate` で当月のカスタム休日を取得してソルバーに渡す
- constraints ページにカスタム休日の登録・一覧・削除UIを追加
- シフト表でカスタム休日を国民祝日と同じ赤表示で反映

## 背景

7/1（開院記念日）が `@holiday-jp/holiday_jp` に存在せず、システムが平日扱いしていた。シニアペア制約（平日に師長/主任のどちらかが必須）が適用された状態で両者がフリーズしていたため、CSP全体が解なしになりシフト生成が失敗していた。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `supabase/migrations/20260610000000_add_custom_holidays.sql` | テーブル作成・RLS設定 |
| `src/types/index.ts` | `CustomHoliday` 型追加 |
| `src/lib/shift-solver-csp.ts` | `SolverInput` 拡張・`isWeekend` 判定修正（5箇所） |
| `src/lib/shift-solver-fallback.ts` | `getDayRequirements`・`isWeekdayDate` に `customHolidayDates` 適用 |
| `src/app/api/shift/generate/route.ts` | `custom_holidays` クエリ追加 |
| `src/app/(app)/constraints/page.tsx` | カスタム休日CRUD UI追加 |
| `src/app/(app)/shift-table/page.tsx` | `isHoliday` 判定拡張・赤表示対応 |

## Test plan

- [ ] Supabaseで `custom_holidays` テーブルにマイグレーションを適用する
- [ ] constraints ページで「2026-07-01 / 開院記念日」を登録できること
- [ ] 同じ日付を重複登録しようとすると「この日付はすでに登録されています」が表示されること
- [ ] 2026年7月のシフト生成が成功すること（7/1がシニアペア制約から除外される）
- [ ] シフト表で7/1が赤背景で表示されること
- [ ] `hard_off_on_holidays: true` のスタッフが7/1に公休として割り当てられること
- [ ] カスタム休日を削除後に再生成すると7/1が平日として扱われること

Closes #87