### PR TITLE
fix: 公休繰越が無視されるバグ（テーブル名 staff_carry_overs → staff_carry_over）

### DIFF
--- a/src/app/api/shift/generate/route.ts
+++ b/src/app/api/shift/generate/route.ts
@@ -93,7 +93,7 @@ export async function POST(request: Request) {
     supabase.from('shift_types').select('*').order('display_order'),
     tailFromBody ? Promise.resolve({ data: null }) :
       supabase.from('shift_assignments').select('staff_id, shift_code, date').in('date', [prevSecondLast, prevLastDay]),
-    supabase.from('staff_carry_overs').select('staff_id, carry_over_days').eq('to_month', year_month),
+    supabase.from('staff_carry_over').select('staff_id, carry_over_days').eq('to_month', year_month),
     supabase.from('custom_holidays').select('date').gte('date', monthStart).lte('date', monthEnd),
   ])
 


### PR DESCRIPTION
## 概要
`/api/shift/generate` route が存在しない複数形テーブル `staff_carry_overs` を参照しており、クエリが空になって**公休繰越が常に無視**されていた。実テーブルは単数形 `staff_carry_over`（scheduler/shift-table は単数形で正しい）。PR #89 のタイポ修正が route 側に効いていなかった退行の是正。

## 変更
- `route.ts`: `from('staff_carry_overs')` → `from('staff_carry_over')`（1行）

## 影響・検証
- 繰越がある月は目標公休数に繰越分が加算される（繰越なしの月は挙動不変）。
- 全3箇所が単数形で統一・tsc/本番ビルド成功・DBに繰越10件(2026-06)実在を確認。